### PR TITLE
Fix multiple tags issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+### What does this PR do?
+
+### How should it be tested manually?

--- a/src/lib/aureliaExtractCleaner.js
+++ b/src/lib/aureliaExtractCleaner.js
@@ -49,7 +49,7 @@ class AureliaExtractCleaner {
      * @ignore
      */
     this._regexs = {
-      requires: /<require.+?from=\\?["|'].*?\\?["|'].*?>(?:.+?)?<\/require>/ig,
+      requires: /<require.+?from=\\?["|'].*?\\?["|'].*?><\/require>/ig,
       attributes: /(\S+)=\\?["']?((?:.(?!["']?\s+(?:\S+)=|\\?[>"']))+.)["']?/ig,
     };
   }

--- a/tests/lib/aureliaExtractCleaner.test.js
+++ b/tests/lib/aureliaExtractCleaner.test.js
@@ -86,6 +86,20 @@ describe('AureliaExtractCleaner', () => {
     `.trim());
   });
 
+  it('shouldn\'t remove a tag located after one to remove', () => {
+    // Given
+    const tagToIgnore = '<require from="some/other/path/to/file.scss"></require>';
+    const customCode = `
+      <require from="some/path/to/file.scss" extract="true"></require>
+      ${tagToIgnore}
+    `;
+    // When
+    const cleaner = new AureliaExtractCleaner(customCode);
+    const processed = cleaner.process().trim();
+    // Then
+    expect(processed).toBe(tagToIgnore);
+  });
+
   it('shouldn\'t change the code if there are no require tags', () => {
     // Given
     const customCode = '<gotham>Batman</gotham>';


### PR DESCRIPTION
### What does this PR do?

I suck at writing regular expressions: The regex I made for extracting the `require` tags was capturing all adjacent tags 😭 :

In cases like this one:

```html
<require from="file.scss" extract="true"></require>
<require from="some/component"></require>
```

It was removing both tags.

And I also added the GitHub PR template.

### How should it be tested manually?

Running the tests. I added a specific test for the case.